### PR TITLE
Fix isterminal bug

### DIFF
--- a/src/VDPTag2.jl
+++ b/src/VDPTag2.jl
@@ -21,7 +21,7 @@ const Vec8 = SVector{8, Float64}
 import Base: rand, eltype, convert
 import MCTS: next_action, n_children
 import ParticleFilters: obs_weight
-import POMDPs: actions
+import POMDPs: actions, isterminal
 
 export
     TagState,
@@ -50,6 +50,7 @@ export
     ManageUncertainty,
     CardinalBarriers,
     mdp
+    isterminal
 
 struct TagState
     agent::Vec2


### PR DESCRIPTION
Under v0.8, the simulation step-through (e.g., `POMDPs.simulate(hr, pomdp, policy)`) does not terminate upon the `isterminal` signal.

It turns out that in `VDPTag2.jl`, the `isterminal` function is not overriding `POMDPs.isterminate` properly due to the lack of missing import. This PR fixes that.