### PR TITLE
fix discrete initialstate and type stability

### DIFF
--- a/src/discretized.jl
+++ b/src/discretized.jl
@@ -1,15 +1,15 @@
 import POMDPs.initialstate
 const IVec8 = SVector{8, Int}
 
-@with_kw struct AODiscreteVDPTagPOMDP <: POMDP{TagState, Int, IVec8}
-    cpomdp::VDPTagPOMDP = VDPTagPOMDP()
-    n_angles::Int       = 10
-    binsize::Float64    = 0.5
+@with_kw struct AODiscreteVDPTagPOMDP{B} <: POMDP{TagState, Int, IVec8}
+    cpomdp::VDPTagPOMDP{B}  = VDPTagPOMDP()
+    n_angles::Int           = 10
+    binsize::Float64        = 0.5
 end
 
-@with_kw struct ADiscreteVDPTagPOMDP <: POMDP{TagState, Int, Vec8}
-    cpomdp::VDPTagPOMDP = VDPTagPOMDP()
-    n_angles::Int       = 10
+@with_kw struct ADiscreteVDPTagPOMDP{B} <: POMDP{TagState, Int, Vec8}
+    cpomdp::VDPTagPOMDP{B}  = VDPTagPOMDP()
+    n_angles::Int           = 10
 end
 
 
@@ -107,7 +107,7 @@ function POMDPs.observation(p::AODiscreteVDPTagPOMDP, s::TagState, a::Int, sp::T
     end
 end
 
-POMDPs.initialstate(p::AODiscreteVDPTagPOMDP) = VDPInitDist()
+POMDPs.initialstate(p::DiscreteVDPTagProblem) = VDPInitDist()
 
 #=
 gauss_cdf(mean, std, x) = 0.5*(1.0+erf((x-mean)/(std*sqrt(2))))


### PR DESCRIPTION
1. `initialstate` was previously defined for `AODiscreteVDPTagPOMDP` but not `ADiscreteVDPTagPOMDP`
2. The continuous `VDPTagPOMDP` had parametric field `B` which was not accounted for in the discrete versions leading to type instability.

```julia
pomdp = ADiscreteVDPTagPOMDP()
b0 = initialstate(pomdp)
s = rand(b0)
a = rand(actions(pomdp))
@btime POMDPs.gen($pomdp, $s, $a, $Random.GLOBAL_RNG)
```
Prior to the type stability change:
`2.267 μs (11 allocations: 672 bytes)`

After the type stability change:
`369.417 ns (3 allocations: 288 bytes)`